### PR TITLE
- Close database connection on PhpEarth\Swoole\Driver\Symfony\Driver::postHandle()

### DIFF
--- a/src/Driver/Symfony/Driver.php
+++ b/src/Driver/Symfony/Driver.php
@@ -109,6 +109,11 @@ class Driver
      */
     public function postHandle()
     {
+        //close mysql connection.
+        $this->kernel->getContainer()->get('doctrine.orm.entity_manager')->clear();
+        $this->kernel->getContainer()->get('doctrine.orm.entity_manager')->close();
+        $this->kernel->getContainer()->get('doctrine.orm.entity_manager')->getConnection()->close();
+
         $this->kernel->terminate($this->symfonyRequest, $this->symfonyResponse);
     }
 


### PR DESCRIPTION
This is a fix to avoid "Too many connections".